### PR TITLE
Fix bug that caused git_info.h to not generate

### DIFF
--- a/embed_git_info.py
+++ b/embed_git_info.py
@@ -63,7 +63,7 @@ def calculate_crc(filename):
 def write_header(info, crc):
     # Construct the path to the header file
     header_file_name = 'git_info.h'
-    header_path = os.path.join("$PROGPATH",'include', header_file_name)
+    header_path = os.path.join('include', header_file_name)
     # Construct the guard ID for the header file
     guard_id = header_file_name.replace('.', '_').upper()
     # Open the header file in write mode

--- a/embed_git_info.py
+++ b/embed_git_info.py
@@ -63,7 +63,7 @@ def calculate_crc(filename):
 def write_header(info, crc):
     # Construct the path to the header file
     header_file_name = 'git_info.h'
-    header_path = os.path.join('include', header_file_name)
+    header_path = os.path.join($"src_dir", 'include', header_file_name)
     # Construct the guard ID for the header file
     guard_id = header_file_name.replace('.', '_').upper()
     # Open the header file in write mode

--- a/embed_git_info.py
+++ b/embed_git_info.py
@@ -63,7 +63,7 @@ def calculate_crc(filename):
 def write_header(info, crc):
     # Construct the path to the header file
     header_file_name = 'git_info.h'
-    header_path = os.path.join($"src_dir", 'include', header_file_name)
+    header_path = os.path.join('src', header_file_name)
     # Construct the guard ID for the header file
     guard_id = header_file_name.replace('.', '_').upper()
     # Open the header file in write mode

--- a/embed_git_info.py
+++ b/embed_git_info.py
@@ -67,20 +67,26 @@ def write_header(info, crc):
     # Construct the guard ID for the header file
     guard_id = header_file_name.replace('.', '_').upper()
     # Open the header file in write mode
-    with open(header_path, 'w') as f:
-        # Write the header guard
-        f.write(f"#ifndef {guard_id}\n")
-        f.write(f"#define {guard_id}\n")
-        # Iterate over the Git information
-        for key, value in info.items():
-            # Write each piece of information as a const variable
-            f.write(f"const char {key.upper()}[] = \"{value}\";\n")
-        # Write the CRC information
-        if USE_CRC:
-            f.write(f"const long MAIN_FILE_CRC = {crc};\n")
-        # End of header guard
-        f.write(f"#endif // {guard_id}\n")
-    # Add the path of the header file to the .gitignore file
+    try:
+        with open(header_path, 'w') as f:
+            # Write the header guard
+            f.write(f"#ifndef {guard_id}\n")
+            f.write(f"#define {guard_id}\n")
+            # Iterate over the Git information
+            for key, value in info.items():
+                # Write each piece of information as a const variable
+                f.write(f"const char {key.upper()}[] = \"{value}\";\n")
+            # Write the CRC information
+            if USE_CRC:
+                f.write(f"const long MAIN_FILE_CRC = {crc};\n")
+            # End of header guard
+            f.write(f"#endif // {guard_id}\n")
+    except FileNotFoundError:
+        print(f"Could not find the header file: {header_path}")
+    except PermissionError:
+        print(f"Error")
+    except Exception as e:
+        print(f"An error occurred: {e}")
 
 # Main execution block
 try:

--- a/embed_git_info.py
+++ b/embed_git_info.py
@@ -63,7 +63,7 @@ def calculate_crc(filename):
 def write_header(info, crc):
     # Construct the path to the header file
     header_file_name = 'git_info.h'
-    header_path = os.path.join('src', header_file_name)
+    header_path = os.path.join("$PROGPATH",'include', header_file_name)
     # Construct the guard ID for the header file
     guard_id = header_file_name.replace('.', '_').upper()
     # Open the header file in write mode

--- a/include/git_info.h
+++ b/include/git_info.h
@@ -1,0 +1,1 @@
+// This is a blank file that will be auto-populated with git information


### PR DESCRIPTION
In 1.7.0 git_info was generating but in project rather then library.
In 1.7.1 git_info was not generating due to path issues
Bug is fixed in this pull request