### PR TITLE
ignore pylance error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # README #
-Version 1.7.2
+Version 1.7.3
 
 ### Security Note ###
 This script will have access to your file system using python. It will not modify any files, but it will read them. If you are concerned about security, you may want to look at the script and make sure it is not doing anything malicious. It is a very simple script, so it should be easy to understand.

--- a/embed_git_info.py
+++ b/embed_git_info.py
@@ -1,7 +1,7 @@
 # https://bitbucket.org/exploratorium/pio-git-info-serial-print
 
 # Importing the environment from PlatformIO and necessary modules
-Import("env")
+Import('env') # type: ignore
 
 import subprocess # For executing shell commands
 import os      # For file path operations

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "PlatformIO Git Info Serial Print",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "This library is used to print git information to the serial port. It is used in conjunction with the PlatformIO build system, using it's local python interpreter to run the git commands and abstract them to a header file.",
   "keywords": "extrascript, python, helper, script, git",
   "repository":


### PR DESCRIPTION
Remove error popup saying that the import("env") is not defined.